### PR TITLE
URIjs -> urijs fix

### DIFF
--- a/lib/opensubtitles.js
+++ b/lib/opensubtitles.js
@@ -1,7 +1,7 @@
 var xmlrpc = require('xmlrpc'),
     pjson = require('../package.json'),
     Promise = require('bluebird'),
-    URIjs = require('URIjs'),
+    URIjs = require('urijs'),
     url = 'http://api.opensubtitles.org:80/xml-rpc';
     url_ssl = 'https://api.opensubtitles.org:443/xml-rpc';
 


### PR DESCRIPTION
URIjs no longer exists.

This fixs the "Cannot find module 'URIjs' error.
